### PR TITLE
add deprecation warning when using the gem with API V1

### DIFF
--- a/lib/wanikani/client.rb
+++ b/lib/wanikani/client.rb
@@ -79,6 +79,8 @@ module Wanikani
     def api_response(resource, optional_arg = nil)
       raise ArgumentError, "You must define a resource to query WaniKani" if resource.nil? || resource.empty?
 
+      warn Kernel.caller.first + " access to Wanikani API v1 is deprecated. Please update to Gem version 3.0+ to support API v2."
+
       begin
         res = client.get("/api/#{@api_version}/user/#{@api_key}/#{resource}/#{optional_arg}")
 


### PR DESCRIPTION
Hi,

The idea is to merge this before PR #3 to have a 2.1 gem release adding these deprecation warnings. This gives advice to people still using version 2.0 to update in time and look into the effort they need to plan to update.

Version bump is up to you. :)